### PR TITLE
Update releases, allow custom builds

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -7,10 +7,45 @@ fn main() {
 }
 
 fn get_enzyme() -> Result<(), String> {
-    enzyme::download(Rust)?;
-    enzyme::download(Enzyme)?;
-    enzyme::build(Rust)?;
-    enzyme::generate_bindings()?;
-    enzyme::build(Enzyme)?;
-    Ok(())
+    let mut cmd_line = std::env::args();
+    if cmd_line.len() == 2 {
+        let arg = cmd_line
+            .nth(1)
+            .expect("failed reading")
+            .parse::<String>()
+            .expect("failed reading");
+        return match arg.to_lowercase().as_str() {
+            "rust" => {
+                enzyme::download(Rust)?;
+                enzyme::build(Rust)?;
+                Ok(())
+            }
+            "enzyme" => {
+                enzyme::download(Enzyme)?;
+                enzyme::generate_bindings_from_release()?;
+                enzyme::build(Enzyme)?;
+                Ok(())
+            }
+            "enzyme-head" => {
+                enzyme::download(EnzymeHEAD)?;
+                enzyme::generate_bindings_from_head()?;
+                enzyme::build(EnzymeHEAD)?;
+                Ok(())
+            }
+            _ => return Err(format!(
+                "unknown input given {:?} \nPlease try \"rust\", \"enzyme\", or \"enzyme-head\"",
+                &arg
+            )),
+        };
+    } else if cmd_line.len() == 1 {
+        // Default
+        enzyme::download(Rust)?;
+        enzyme::download(Enzyme)?;
+        enzyme::build(Rust)?;
+        enzyme::generate_bindings_from_release()?;
+        enzyme::build(Enzyme)?;
+        Ok(())
+    } else {
+        Err("To many arguments given".to_string())
+    }
 }

--- a/src/code/downloader.rs
+++ b/src/code/downloader.rs
@@ -1,15 +1,16 @@
-use super::utils;
 use super::utils::Repo;
+use super::utils::{self, run_and_printerror};
 use super::version_manager::*;
 
+use curl::easy::Easy;
 use flate2;
 use flate2::bufread::GzDecoder;
-use std::fs::{File, OpenOptions};
+use std::fs::{remove_dir_all, File, OpenOptions};
 use std::io::prelude::*;
 use std::io::BufReader;
 use std::path::PathBuf;
+use std::process::Command;
 use tar::Archive;
-use curl::easy::Easy;
 
 fn unpack(tar_gz_file: &str, dst: &str) -> Result<(), std::io::Error> {
     let path = tar_gz_file;
@@ -20,6 +21,25 @@ fn unpack(tar_gz_file: &str, dst: &str) -> Result<(), std::io::Error> {
     let mut archive = Archive::new(tar);
     archive.unpack(dst)?;
 
+    Ok(())
+}
+
+fn download_head() -> Result<(), String> {
+    //git clone --depth 1 https://github.com/EnzymeAD/Enzyme
+    let out_dir = utils::get_enzyme_base_path().join("Enzyme-HEAD");
+    if out_dir.exists() {
+        // make space to download the latest head
+        remove_dir_all(out_dir.clone()).expect("failed to delete existing directory!");
+    }
+    let mut command = Command::new("git");
+    command.args(&[
+        "clone",
+        "--depth",
+        "1",
+        "https://github.com/EnzymeAD/Enzyme",
+        out_dir.to_str().unwrap(),
+    ]);
+    run_and_printerror(&mut command);
     Ok(())
 }
 
@@ -54,13 +74,14 @@ fn download_tarball(repo_url: &str, download_filename: PathBuf) -> Result<(), St
     let mut data = Vec::new();
     {
         let mut transfer = handle.transfer();
-        transfer.write_function(|block_data| {
-            data.extend_from_slice(block_data);
-            Ok(block_data.len())
-        }).unwrap();
+        transfer
+            .write_function(|block_data| {
+                data.extend_from_slice(block_data);
+                Ok(block_data.len())
+            })
+            .unwrap();
         transfer.perform().unwrap();
     }
-
 
     dbg!(&download_filename);
     match file.write_all(&data) {
@@ -78,22 +99,23 @@ fn download_tarball(repo_url: &str, download_filename: PathBuf) -> Result<(), St
     Ok(())
 }
 
-
 /// This function can be used to download and unpack release tarballs.
 ///
 /// Only the official [Enzyme](https://github.com/wsmoses/Enzyme) and
 /// [Rust](https://github.com/rust-lang/rust) repositories are supported.
 /// Data will be processed in `~/.cache/enzyme`.
 pub fn download(to_download: Repo) -> Result<(), String> {
-
     // If we have alrady downloaded it in the past, there's nothing left to do.
     if check_downloaded(&to_download) {
         return Ok(());
     }
 
     let (repo, name) = match to_download {
-        Repo::Enzyme => (utils::get_remote_enzyme_tarball_path(), "enzyme"),
         Repo::Rust => (utils::get_remote_rustc_tarball_path(), "rustc"),
+        Repo::Enzyme => (utils::get_remote_enzyme_tarball_path(), "enzyme"),
+        Repo::EnzymeHEAD => {
+            return download_head();
+        }
     };
 
     // Location to store our tarball, before unpacking

--- a/src/code/generate_api.rs
+++ b/src/code/generate_api.rs
@@ -2,9 +2,22 @@ use super::utils;
 use bindgen;
 use std::{fs, path::PathBuf};
 
-/// This function can be used to generate Rust wrappers around Enzyme's [C API](https://github.com/wsmoses/Enzyme/blob/main/enzyme/Enzyme/CApi.h).
-pub fn generate_bindings() -> Result<(), String> {
+/// This function can be used to generate Rust wrappers around Enzyme's [C API](https://github.com/wsmoses/Enzyme/blob/main/enzyme/Enzyme/CApi.h) based on the latest release.
+pub fn generate_bindings_from_release() -> Result<(), String> {
     let capi_header = utils::get_capi_path();
+    let out_file = utils::get_bindings_string();
+    generate_bindings_with(capi_header, out_file)
+}
+
+/// This function can be used to generate Rust wrappers around Enzyme's [C
+/// API](https://github.com/wsmoses/Enzyme/blob/main/enzyme/Enzyme/CApi.h) based on the latest
+/// HEAD.
+pub fn generate_bindings_from_head() -> Result<(), String> {
+    let capi_header = utils::get_enzyme_base_path()
+        .join("Enzyme-HEAD")
+        .join("enzyme")
+        .join("Enzyme")
+        .join("CApi.h");
     let out_file = utils::get_bindings_string();
     generate_bindings_with(capi_header, out_file)
 }

--- a/src/code/mod.rs
+++ b/src/code/mod.rs
@@ -4,7 +4,7 @@ pub mod generate_api;
 pub mod utils;
 pub mod version_manager;
 
-pub use utils::Repo;
 pub use compile::build;
 pub use downloader::download;
-pub use generate_api::generate_bindings;
+pub use generate_api::*;
+pub use utils::Repo;

--- a/src/code/utils.rs
+++ b/src/code/utils.rs
@@ -1,12 +1,28 @@
 use dirs;
-use std::path::PathBuf;
+use std::{path::PathBuf, process::Command};
 
-use super::version_manager::{RUSTC_VER, ENZYME_VER};
+use super::version_manager::{ENZYME_VER, RUSTC_VER};
+
+pub(crate) fn run_and_printerror(command: &mut Command) {
+    println!("Running: `{:?}`", command);
+    match command.status() {
+        Ok(status) => {
+            if !status.success() {
+                panic!("Failed: `{:?}` ({})", command, status);
+            }
+        }
+        Err(error) => {
+            panic!("Failed: `{:?}` ({})", command, error);
+        }
+    }
+}
 
 /// We offer support for downloading and compiling these two repositories.
 pub enum Repo {
-    /// For handling the Enzyme repository.
+    /// For handling the Enzyme repository (latest release).
     Enzyme,
+    /// For handling the Enzyme repository (main branch).
+    EnzymeHEAD,
     /// For handling the Rust repository.
     Rust,
 }
@@ -26,14 +42,12 @@ pub fn get_enzyme_base_path() -> PathBuf {
     enzyme_base_path
 }
 pub fn get_enzyme_repo_path() -> PathBuf {
-    let path = get_enzyme_base_path()
-        .join("Enzyme-".to_owned() + ENZYME_VER);
+    let path = get_enzyme_base_path().join("Enzyme-".to_owned() + ENZYME_VER);
     assert_existence(path.clone());
     path
 }
 fn get_enzyme_subdir_path() -> PathBuf {
-    let path = get_enzyme_repo_path()
-        .join("enzyme");
+    let path = get_enzyme_repo_path().join("enzyme");
     assert_existence(path.clone());
     path
 }
@@ -78,7 +92,7 @@ pub fn get_llvm_header_path() -> PathBuf {
 }
 pub fn get_remote_enzyme_tarball_path() -> String {
     format!(
-        "https://github.com/wsmoses/Enzyme/archive/refs/tags/v{}.tar.gz",
+        "https://github.com/EnzymeAD/Enzyme/archive/refs/tags/v{}.tar.gz",
         ENZYME_VER
     )
 }

--- a/src/code/version_manager.rs
+++ b/src/code/version_manager.rs
@@ -1,10 +1,10 @@
+use super::utils;
+use crate::Repo;
 use std::fs::File;
 use std::path::PathBuf;
-use crate::Repo;
-use super::utils;
 
 pub const ENZYME_VER: &str = "0.0.26";
-pub const RUSTC_VER: &str = "1.57.0";
+pub const RUSTC_VER: &str = "1.58.1";
 
 fn rustc_download_finished() -> PathBuf {
     utils::get_download_dir().join("rustc-".to_owned() + RUSTC_VER + "-ok")
@@ -18,13 +18,19 @@ fn rustc_compile_finished() -> PathBuf {
 fn enzyme_compile_finished() -> PathBuf {
     utils::get_enzyme_build_path().join("enzyme-".to_owned() + ENZYME_VER + "-ok")
 }
-
-
+fn enzyme_compile_head_finished() -> PathBuf {
+    utils::get_enzyme_base_path()
+        .join("Enzyme-HEAD")
+        .join("enzyme")
+        .join("build")
+        .join("enzyme-HEAD-ok")
+}
 
 pub fn check_downloaded(repo: &Repo) -> bool {
     match repo {
         Repo::Rust => rustc_download_finished().exists(),
         Repo::Enzyme => enzyme_download_finished().exists(),
+        Repo::EnzymeHEAD => false, // always trigger download of the latest head
     }
 }
 
@@ -32,16 +38,16 @@ pub fn set_downloaded(repo: &Repo) {
     let path = match repo {
         Repo::Rust => rustc_download_finished(),
         Repo::Enzyme => enzyme_download_finished(),
+        Repo::EnzymeHEAD => return, // we clone directly instead of downloading first
     };
     File::create(&path).expect("Couldn't create downloaded-finished file");
 }
-
-
 
 pub fn check_compiled(repo: &Repo) -> bool {
     match repo {
         Repo::Rust => rustc_compile_finished().exists(),
         Repo::Enzyme => enzyme_compile_finished().exists(),
+        Repo::EnzymeHEAD => enzyme_compile_head_finished().exists(),
     }
 }
 
@@ -49,6 +55,7 @@ pub fn set_compiled(repo: &Repo) {
     let path = match repo {
         Repo::Rust => rustc_compile_finished(),
         Repo::Enzyme => enzyme_compile_finished(),
+        Repo::EnzymeHEAD => enzyme_compile_head_finished(),
     };
     File::create(&path).expect("Couldn't create compilation-finished file");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,5 @@ mod code;
 
 pub use code::compile::build;
 pub use code::downloader::download;
-pub use code::generate_api::generate_bindings;
-pub use code::generate_api::generate_bindings_with;
+pub use code::generate_api::*;
 pub use code::utils::Repo;


### PR DESCRIPTION
Should simplify debugging.
A specific enzyme_build / crate release will still be fixed to specific Enzyme / rustc stable releases,
but it also allows building the latest enzyme head, which should simplify further testing.